### PR TITLE
Add new custom parameters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ xcov.report(
    exclude_targets: 'Demo.app',
    minimum_coverage_percentage: 90,
    minimum_coverage_percentage_for_changed_files: 80,
-   filename_prefix_ignore_list: ['View', 'State']
+   ignore_list_of_minimum_coverage_percentage_for_changed_files: ['View', 'State']
 )
 ```
 
@@ -53,7 +53,7 @@ report = xcov.produce_report(
   exclude_targets: 'Demo.app',
   minimum_coverage_percentage: 90,
   minimum_coverage_percentage_for_changed_files: 80,
-  filename_prefix_ignore_list: ['View', 'State']
+  ignore_list_of_minimum_coverage_percentage_for_changed_files: ['View', 'State']
 )
 
 # Do some custom filtering with the report here
@@ -64,8 +64,8 @@ xcov.output_report(report)
 
 ## Updates in the plugin
 - Added `minimum_coverage_percentage_for_changed_files` parameter to allow minimum coverage for new and modified files only.
-- Added `filename_prefix_ignore_list` parameter to allow skipping files based on the architecture of the project.
-   - For example, if the parameter is like `filename_prefix_ignore_list: ['View', 'State']`, then any filename which contains the word `View` or `State` will be skipped from this coverage check.
+- Added `ignore_list_of_minimum_coverage_percentage_for_changed_files` parameter to allow skipping files based on the architecture of the project.
+   - For example, if the parameter is like `ignore_list_of_minimum_coverage_percentage_for_changed_files: ['View', 'State']`, then any filename which **contains** the word `View` or `State` will be skipped from this coverage check.
 
 ## Linking this custom support to your repo
 Add this to your gemfile instead of `danger-xcov`, point it to this fork.

--- a/README.md
+++ b/README.md
@@ -13,12 +13,6 @@
 [xcov](https://github.com/nakiostudio/xcov), a friendly visualizer for Xcode's
 code coverage files.
 
-<h3 align="center">
-  <a href="https://grnh.se/5f21b9701">
-    <img src="/assets_readme/monzo.png" alt="Join me and the amazing Mobile Team at monzo"/>
-  </a>
-</h3>
-
 ## Installation
 
 ```
@@ -36,7 +30,9 @@ xcov.report(
    scheme: 'EasyPeasy',
    workspace: 'Example/EasyPeasy.xcworkspace',
    exclude_targets: 'Demo.app',
-   minimum_coverage_percentage: 90
+   minimum_coverage_percentage: 90,
+   minimum_coverage_percentage_for_changed_files: 80,
+   filename_prefix_ignore_list: ['View', 'State']
 )
 ```
 
@@ -55,13 +51,26 @@ report = xcov.produce_report(
   scheme: 'EasyPeasy',
   workspace: 'Example/EasyPeasy.xcworkspace',
   exclude_targets: 'Demo.app',
-  minimum_coverage_percentage: 90
+  minimum_coverage_percentage: 90,
+  minimum_coverage_percentage_for_changed_files: 80,
+  filename_prefix_ignore_list: ['View', 'State']
 )
 
 # Do some custom filtering with the report here
 
 # Post markdown report
 xcov.output_report(report)
+```
+
+## Updates in the plugin
+- Added `minimum_coverage_percentage_for_changed_files` parameter to allow minimum coverage for new and modified files only.
+- Added `filename_prefix_ignore_list` parameter to allow skipping files based on the architecture of the project.
+   - For example, if the parameter is like `filename_prefix_ignore_list: ['View', 'State']`, then any filename which contains the word `View` or `State` will be skipped from this coverage check.
+
+## Linking this custom support to your repo
+Add this to your gemfile instead of `danger-xcov`, point it to this fork.
+```ruby
+gem 'danger-xcov', :git => 'https://github.com/rakutentech/danger-xcov.git'
 ```
 
 ## License

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -17,7 +17,7 @@ module Danger
   #      exclude_targets: 'Demo.app',
   #      minimum_coverage_percentage: 90,
   #      minimum_coverage_percentage_for_changed_files: 80.0,
-  #      filename_prefix_ignore_list: ['View', 'Cell', 'Layout', 'Action', 'State'],
+  #      ignore_list_of_minimum_coverage_percentage_for_changed_files: ['View', 'Cell', 'Layout', 'Action', 'State'],
   #    )
   #
   # @tags xcode, coverage, xccoverage, tests, ios, xcov
@@ -90,25 +90,14 @@ module Danger
       end
 
       # Notify failure if minimum coverage hasn't been reached for modified/added files
-      file_threshold = args.first[:minimum_coverage_percentage_for_changed_files].to_i
-      ignore_list = args.first[:filename_prefix_ignore_list]
-      if !file_threshold.nil?
+      file_threshold = args.first[:minimum_coverage_percentage_for_changed_files].to_i || 0
+      ignore_list = args.first[:ignore_list_of_minimum_coverage_percentage_for_changed_files] || []
+
+      if file_threshold > 0
         report.targets.each do |target|
-          target.files.each do |file|
-            if ((file.coverage * 100) < file_threshold) #check if file coverage is less than that defined
-              if !ignore_list.nil? #check is ignore list is provided or not
-                ignore_list.each do |ignore|
-                  if (!file.name.include? ignore)
-                    fail("Class code coverage is below minimum. Improve #{file.name} to at least #{file_threshold}%")
-                  else
-                    puts("File #{file.name} is being skipped from minimum code coverage because it contains '#{ignore}' keyword.")
-                  end
-                end
-              else
-                fail("Class code coverage is below minimum, please improve #{file.name} to at least #{file_threshold}%")
-              end
-            end
-          end
+          target_files = target.files.select { |file| ignore_list.none? { |contains| file.name.include? contains } }
+          violations = target_files.select { |file| file.coverage * 100) < file_threshold}
+          fail("Class code coverage is below minimum, please improve #{violations.map {|f| f.name }} to at least #{file_threshold}%.") if !violations.empty?
         end
       end
     end
@@ -136,7 +125,7 @@ module Danger
       converted_options = options.dup
       converted_options.delete(:verbose)
       converted_options.delete(:minimum_coverage_percentage_for_changed_files)
-      converted_options.delete(:filename_prefix_ignore_list)
+      converted_options.delete(:ignore_list_of_minimum_coverage_percentage_for_changed_files)
       converted_options
     end
 


### PR DESCRIPTION
Added below new parameters:
- `minimum_coverage_percentage_for_changed_files` -> This parameter allows us to do coverage check against new and modified files.
- `filename_prefix_ignore_list` -> This parameter allows us to pass filenames which should be ignored when doing coverage check for new and modified files. 

Please see readme for more details.